### PR TITLE
remove reopening of port after flashing

### DIFF
--- a/src/components/LandingHero.tsx
+++ b/src/components/LandingHero.tsx
@@ -289,15 +289,6 @@ export default function LandingHero() {
       setStatus('Flashing completed. Restarting device...')
       await loader.hardReset()
       
-      // Reopen port for normal operation
-      await serialPortRef.current.open({ 
-        baudRate: 115200,
-        dataBits: 8,
-        stopBits: 1,
-        parity: 'none',
-        flowControl: 'none'
-      });
-      
       setStatus('Flashing completed successfully! Device has been restarted.')
     } catch (error) {
       console.error('Flashing failed:', error)


### PR DESCRIPTION
after successful flashing, we are attempting to reopen the serial port but it fails because it's already open. this pr simply removes the reopening since it doesn't appear to be needed.

closes #2 