### PR TITLE
Handle the delay after 100% complete better

### DIFF
--- a/src/components/LandingHero.tsx
+++ b/src/components/LandingHero.tsx
@@ -231,10 +231,10 @@ export default function LandingHero() {
         terminal: {
           clean() { },
           writeLine(data: string) {
-            setStatus(data);
+            // setStatus(data);
           },
           write(data: string) {
-            setStatus(data);
+            // setStatus(data);
           },
         },
       });
@@ -267,7 +267,12 @@ export default function LandingHero() {
         eraseAll: false,
         compress: true,
         reportProgress: (fileIndex, written, total) => {
-          setStatus(t('status.flashing', { percent: Math.round((written / total) * 100) }))
+          const percent = Math.round((written / total) * 100)
+          if (percent == 100) {
+            setStatus(t('status.completed'))
+          } else {
+            setStatus(t('status.flashing', { percent: percent }))
+          }
         },
         calculateMD5Hash: () => '',
       })

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -62,7 +62,7 @@
       "connectFirst": "Please connect to a device first",
       "preparing": "Preparing to flash...",
       "flashing": "Flashing: {{percent}}% complete",
-      "completed": "Flashing completed. Restarting device...",
+      "completed": "Flashing completed. Restarting device, please wait...",
       "success": "Flashing completed successfully! Device has been restarted.",
       "loggingStarted": "Serial logging started..."
     },


### PR DESCRIPTION
Turns out the terminal was overwriting whatever reportProgress was doing.   This is what it looks like with these changes


https://github.com/user-attachments/assets/b64138c3-f28e-46a8-ae1d-b28160d5353b



#10 