### PR TITLE
fix: selectedFirmware is needed

### DIFF
--- a/src/components/LandingHero.tsx
+++ b/src/components/LandingHero.tsx
@@ -397,7 +397,7 @@ export default function LandingHero() {
               <Button
                 className="w-full"
                 onClick={handleStartFlashing}
-                disabled={!selectedDevice || !selectedBoardVersion || isConnecting || isFlashing || !isConnected}
+                disabled={!selectedDevice || !selectedBoardVersion || !selectedFirmware || isConnecting || isFlashing || !isConnected}
               >
                 {isFlashing ? t('hero.flashing') : t('hero.startFlashing')}
                 <Zap className="ml-2 h-4 w-4" />

--- a/src/components/LandingHero.tsx
+++ b/src/components/LandingHero.tsx
@@ -212,6 +212,11 @@ export default function LandingHero() {
       setStatus(t('status.selectBoth'))
       return
     }
+    
+    if (!selectedFirmware) {
+      setStatus(t('status.selectBoth'))
+      return
+    }
 
     setIsFlashing(true)
     setStatus(t('status.preparing'))


### PR DESCRIPTION
fixes #18 
selectedFirmware was not needed so I added it to it.

Bug bounty granted on that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the flashing process validation to require a firmware selection alongside device and board version. This update ensures that all necessary conditions are met before the flashing process can be initiated, preventing unintended actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->