### PR TITLE
feat(i18n): add Simplified Chinese (zh-CN) localization

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -13,7 +13,8 @@ const LanguageSelector = () => {
     { value: 'ru', label: 'Русский' },
     { value: 'tr', label: 'Türkçe' },
     { value: 'sk', label: 'Slovenský' },
-    { value: 'ro', label: 'Română' }
+    { value: 'ro', label: 'Română' },
+    { value: 'zh-CN', label: '简体中文' }
   ];
 
   const handleLanguageChange = (value: string) => {

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -11,6 +11,7 @@ import sk from './locales/sk.json';
 import it from './locales/it.json';
 import tlh from './locales/tlh.json';
 import ro from './locales/ro.json';
+import zhCN from './locales/zh-CN.json';
 
 i18n
   .use(LanguageDetector)
@@ -25,7 +26,8 @@ i18n
       ru: { translation: ru },
       tr: { translation: tr },
       sk: { translation: sk },
-      ro: { translation: ro }
+      ro: { translation: ro },
+      'zh-CN': { translation: zhCN }
     },
     fallbackLng: 'en',
     lng: 'en', // Set default language to English

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1,0 +1,78 @@
+{
+    "common": {
+      "theme": "主题",
+      "language": "语言",
+      "dark": "深色",
+      "light": "浅色"
+    },
+    "header": {
+      "home": "首页",
+      "features": "功能特性",
+      "instructions": "使用说明"
+    },
+    "hero": {
+      "title": "直接在浏览器中刷写你的 Bitaxe",
+      "description": "连接设备，选择型号和板卡版本，立即开始刷写。无需任何配置。",
+      "getStarted": "开始使用",
+      "connect": "连接",
+      "disconnect": "断开连接",
+      "selectDevice": "选择设备",
+      "selectBoard": "选择板卡版本",
+      "selectFirmware": "选择固件版本",
+      "loadingFirmware": "正在加载固件版本...",
+      "startFlashing": "开始刷写",
+      "flashing": "刷写中...",
+      "startLogging": "开始记录日志",
+      "stopLogging": "停止记录日志",
+      "downloadLogs": "下载日志",
+      "loggingDescription": "连接设备，记录串口数据并稍后下载。",
+      "keepConfig": "保留配置"
+    },
+    "features": {
+      "title": "主要特性",
+      "fastFlashing": {
+        "title": "快速刷写",
+        "description": "在数秒内完成 Bitaxe 的刷写，而非数分钟。"
+      },
+      "webBased": {
+        "title": "基于 Web",
+        "description": "无需安装特殊软件，直接使用浏览器即可。"
+      },
+      "multipleBoards": {
+        "title": "多板卡支持",
+        "description": "支持多种 Bitaxe 板卡和模块。"
+      }
+    },
+    "instructions": {
+      "title": "使用方法",
+      "steps": {
+        "1": "将你的 Bitaxe 连接到电脑。",
+        "2": "点击「连接设备」，在弹出窗口中选择你的设备。",
+        "3": "在下拉菜单中选择设备型号。",
+        "4": "选择对应的板卡版本。",
+        "5": "点击「开始刷写」以启动刷写流程。",
+        "6": "等待刷写过程完成。",
+        "7": "断开连接并重启设备。"
+      },
+      "moreInfo": "如需更详细的说明，请参阅我们的",
+      "documentation": "文档"
+    },
+    "status": {
+      "connecting": "正在连接设备...",
+      "connected": "连接成功！",
+      "selectBoth": "请同时选择设备型号和板卡版本",
+      "connectFirst": "请先连接设备",
+      "preparing": "正在准备刷写...",
+      "downloadFirmware": "正在下载固件...",
+      "flashing": "刷写中：{{percent}}% 完成",
+      "completed": "刷写完成，正在重启设备，请稍候...",
+      "success": "刷写成功！设备已重启。",
+      "loggingStarted": "串口日志记录已启动..."
+    },
+    "errors": {
+      "browserCompatibility": {
+        "title": "浏览器兼容性错误",
+        "description": "此应用需要基于 Chromium 的浏览器（如 Google Chrome、Microsoft Edge 或 Brave）才能正常运行。请切换至兼容的浏览器后重试。"
+      }
+    }
+  }


### PR DESCRIPTION
## Summary

- Add `src/i18n/locales/zh-CN.json` with full Simplified Chinese translations covering all existing keys (`common`, `header`, `hero`, `features`, `instructions`, `status`, `errors`)
- Register `zh-CN` as a supported language in `src/i18n/config.ts`
- Add `简体中文` option to the language selector dropdown in `LanguageSelector.tsx`

## Changes

| File | Change |
|------|--------|
| `src/i18n/locales/zh-CN.json` | New file — complete zh-CN translation |
| `src/i18n/config.ts` | Import and register `zh-CN` resource |
| `src/components/LanguageSelector.tsx` | Add `{ value: 'zh-CN', label: '简体中文' }` to language list |

## Testing

1. Open the app in a Chromium-based browser
2. Open the language selector
3. Choose **简体中文**
4. Verify all UI strings are displayed in Simplified Chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Simplified Chinese language support. Users can now select Simplified Chinese as their preferred language for the app interface, with complete translation coverage for all UI elements, including navigation, features, and system messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->